### PR TITLE
Fix login label bug

### DIFF
--- a/components/login-form.tsx
+++ b/components/login-form.tsx
@@ -34,7 +34,7 @@ export function LoginForm({ className, ...props }: React.ComponentProps<'div'>) 
             </div>
 
             <div className='grid gap-3'>
-              <Label htmlFor='email'>Password</Label>
+              <Label htmlFor='password'>Password</Label>
               <Input id='password' name='password' type='password' required />
             </div>
 


### PR DESCRIPTION
## Summary
- fix label reference for password field in `LoginForm`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688382ed31fc83229a10f75ccd8881cc