### PR TITLE
Implement logout in sidebar user menu

### DIFF
--- a/components/nav-user.tsx
+++ b/components/nav-user.tsx
@@ -8,6 +8,9 @@ import {
   IconUserCircle,
 } from "@tabler/icons-react"
 
+import { useRouter } from "next/navigation"
+import { createClient } from "@/utils/supabase/client"
+
 import {
   Avatar,
   AvatarFallback,
@@ -39,6 +42,12 @@ export function NavUser({
   }
 }) {
   const { isMobile } = useSidebar()
+  const router = useRouter()
+  const handleLogout = async () => {
+    const supabase = createClient()
+    await supabase.auth.signOut()
+    router.push('/login')
+  }
 
   return (
     <SidebarMenu>
@@ -98,7 +107,7 @@ export function NavUser({
               </DropdownMenuItem>
             </DropdownMenuGroup>
             <DropdownMenuSeparator />
-            <DropdownMenuItem>
+            <DropdownMenuItem onClick={handleLogout}>
               <IconLogout />
               Log out
             </DropdownMenuItem>


### PR DESCRIPTION
## Summary
- add router and Supabase client imports to `NavUser`
- implement `handleLogout` in the sidebar menu

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68855f7e9d30832291810ca153d0e2f6