### PR TITLE
Improve OTP form UI with toast feedback

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import { Toaster } from "@/components/ui/sonner";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -27,6 +28,7 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
+        <Toaster />
         {children}
       </body>
     </html>

--- a/components/InputOTPForm.tsx
+++ b/components/InputOTPForm.tsx
@@ -63,7 +63,10 @@ export function InputOTPForm({ email }: InputOTPFormProps) {
 
   return (
     <Form {...form}>
-      <form onSubmit={form.handleSubmit(onSubmit)} className='w-2/3 space-y-6'>
+      <form
+        onSubmit={form.handleSubmit(onSubmit)}
+        className='mx-auto flex w-full max-w-md flex-col items-center space-y-6 text-center'
+      >
         <FormField
           control={form.control}
           name='pin'
@@ -71,14 +74,36 @@ export function InputOTPForm({ email }: InputOTPFormProps) {
             <FormItem>
               <FormLabel>One-Time Password</FormLabel>
               <FormControl>
-                <InputOTP maxLength={6} {...field}>
+                <InputOTP
+                  maxLength={6}
+                  containerClassName='justify-center'
+                  {...field}
+                >
                   <InputOTPGroup>
-                    <InputOTPSlot index={0} />
-                    <InputOTPSlot index={1} />
-                    <InputOTPSlot index={2} />
-                    <InputOTPSlot index={3} />
-                    <InputOTPSlot index={4} />
-                    <InputOTPSlot index={5} />
+                    <InputOTPSlot
+                      index={0}
+                      className='h-12 w-12 text-lg'
+                    />
+                    <InputOTPSlot
+                      index={1}
+                      className='h-12 w-12 text-lg'
+                    />
+                    <InputOTPSlot
+                      index={2}
+                      className='h-12 w-12 text-lg'
+                    />
+                    <InputOTPSlot
+                      index={3}
+                      className='h-12 w-12 text-lg'
+                    />
+                    <InputOTPSlot
+                      index={4}
+                      className='h-12 w-12 text-lg'
+                    />
+                    <InputOTPSlot
+                      index={5}
+                      className='h-12 w-12 text-lg'
+                    />
                   </InputOTPGroup>
                 </InputOTP>
               </FormControl>


### PR DESCRIPTION
## Summary
- center OTP form and enlarge inputs
- add `<Toaster />` to the layout so toast messages render

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688604760bbc832283c69da490cb999e